### PR TITLE
Add GET endpoint and move stuff around

### DIFF
--- a/milton-processor/index.ts
+++ b/milton-processor/index.ts
@@ -1,25 +1,12 @@
-import express = require('express');
 import fs = require('fs');
-import { readability } from "./lib";
+import { app } from "./scribe";
 
 const PORT = Number(process.env.PORT) || 8080;
-const app = express();
 
 const serverSecret = fs.readFileSync('secret', 'utf8').trim();
 function authenticated(secret: string): boolean {
   return secret === serverSecret
 }
-
-app.use(express.json({limit: '5mb'}));
-
-app.post("/extract", (req, res) => {
-  if (!authenticated(req.body.secret)) {
-    res.status(403).send('invalid secret');
-    return;
-  }
-
-  res.send(readability(req.body.page));
-});
 
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);

--- a/milton-processor/index.ts
+++ b/milton-processor/index.ts
@@ -3,11 +3,6 @@ import { app } from "./scribe";
 
 const PORT = Number(process.env.PORT) || 8080;
 
-const serverSecret = fs.readFileSync('secret', 'utf8').trim();
-function authenticated(secret: string): boolean {
-  return secret === serverSecret
-}
-
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
 });

--- a/milton-processor/package.json
+++ b/milton-processor/package.json
@@ -15,7 +15,7 @@
     "start": "node ./index.js",
     "gcp-build": "tsc -p .",
     "deploy-appengine": "gcloud app deploy",
-    "deploy-function": "gcloud functions deploy scribe --runtime nodejs10 --allow-unauthenticated --trigger-http"
+    "deploy-function": "gcloud functions deploy scribe --runtime nodejs10 --allow-unauthenticated --trigger-http --memory 512MB"
   },
   "dependencies": {
     "dompurify": "^2.0.8",

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -9,10 +9,12 @@ app.get("/", (req, res) => {
 });
 
 app.post("/extract", (req, res) => {
+  console.log(`Extracting URL: ${req.body.page}`)
   res.send(readability(req.body.page));
 });
 
 app.post("/simplify", (req, res) => {
+  console.log(`Simplifying URL: ${req.body.page}`)
   fetchArticle(req.body.page, (content, err) => {
     if (err) {
       res.status(422).send(`Unable to fetch page: ${err.message}`);
@@ -26,6 +28,7 @@ app.get("/simplify", (req, res) => {
   if (!req.query.page) {
     res.status(200).send(`Please specify the page parameter`)
   } else {
+    console.log(`Simplifying URL: ${req.query.page.toString()}`)
     fetchArticle(req.query.page.toString(), (content, err) => {
       if (err) {
         res.status(422).send(`Unable to fetch page: ${err.message}`)

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -9,7 +9,6 @@ app.get("/", (req, res) => {
 });
 
 app.post("/extract", (req, res) => {
-  console.log(`Extracting URL: ${req.body.page}`)
   res.send(readability(req.body.page));
 });
 

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -1,31 +1,77 @@
 import express = require('express')
-import { readability, fetcherFor } from "./lib";
+import { ReadableOutput, readability, fetchArticle } from "./lib";
 
-const app = express();
+export const app = express();
 app.use(express.json({limit: '5mb'}));
 
 app.get("/", (req, res) => {
   res.status(200).send('Article scribe ready!');
-})
+});
 
 app.post("/extract", (req, res) => {
   res.send(readability(req.body.page));
 });
 
 app.post("/simplify", (req, res) => {
-  fetcherFor(req.body.page).get(req.body.page, (resp) => {
-    let data = '';
-
-    resp.on('data', (chunk) => {
-      data += chunk;
-    });
-
-    resp.on('end', () => {
-      res.send(readability(data));
-    });
-  }).on("error", (err) => {
-    res.status(422).send(`Unable to fetch page: ${err.message}`);
+  fetchArticle(req.body.page, (content, err) => {
+    if (err) {
+      res.status(422).send(`Unable to fetch page: ${err.message}`);
+    } else {
+      res.send(readability(content));
+    }
   });
+});
+
+app.get("/simplify", (req, res) => {
+  if (!req.query.page) {
+    res.status(200).send(`Please specify the page parameter`)
+  } else {
+    fetchArticle(req.query.page.toString(), (content, err) => {
+      if (err) {
+        res.status(422).send(`Unable to fetch page: ${err.message}`)
+      } else {
+        const simplified: ReadableOutput = readability(content);
+
+        const simpleArticleHtml = `
+          <html>
+            <head>
+              <title>Milton Scribe</title>
+              <style type="text/css">
+                body {
+                  margin: 40px auto;
+                  max-width: 650px;
+                  line-height: 1.6;
+                  font-size: 18px;
+                  color: #444;
+                  background-color: #EEEEEE;
+                  padding: 0 10px;
+                }
+                h1,h2,h3 {
+                  line-height:1.2;
+                }
+                @media (prefers-color-scheme: dark) {
+                  body {
+                      color: #CCCCCC;
+                      background-color: #121212;
+                  }
+                  a {
+                    color: #BB86FC;
+                  }
+              }
+              </style>
+            </head>
+            <body>
+              <div class="reader">
+                <h1>${simplified.title}</h1>
+                ${simplified.content}
+              </div>
+            </body>
+          </html>`
+
+        res.send(simpleArticleHtml);
+      }
+    });
+  }
 });
 
 exports.scribe = app;


### PR DESCRIPTION
Adds a get endpoint to easily see what the "readabilitied" page will look like (now with dark mode support).

Example Usage: https://us-central1-dsouza-proving-ground.cloudfunctions.net/scribe/simplify?page=http://www.overcomingbias.com/2008/02/my-favorite-lia.html