### PR TITLE
Add timestamps and cached endpoint

### DIFF
--- a/milton-processor/cache.ts
+++ b/milton-processor/cache.ts
@@ -76,6 +76,7 @@ function urlToFile(url: string): gcs.File {
   const storage = createStorageClient();
   const bucket = storage.bucket('scribe-storage');
   const key = urlToKey(url);
+  console.debug(`URL ${url} located at: ${key}`);
   return bucket.file(key);
 }
 

--- a/milton-processor/cache.ts
+++ b/milton-processor/cache.ts
@@ -14,7 +14,6 @@ export interface ManuscriptData {
   content: string;
   cachedAt: number;
   updatedAt: number;
-  tags: string[];
 }
 
 export class Manuscript {
@@ -22,24 +21,6 @@ export class Manuscript {
 
   constructor(data: ManuscriptData) {
     this.data = data;
-  }
-
-  addTag(tag: string): boolean {
-    const isNew = !this.data.tags.includes(tag);
-    if (isNew) {
-      this.data.tags.push(tag);
-      this.updateUpdatedAt();
-    }
-    return isNew;
-  }
-
-  removeTag(tag: string): boolean {
-    const exists = this.data.tags.includes(tag);
-    if (exists) {
-      this.data.tags = this.data.tags.filter((t) => t !== tag);
-      this.updateUpdatedAt();
-    }
-    return exists;
   }
 
   updateUpdatedAt() {

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -66,7 +66,6 @@ app.post("/simplify", async (req, res) => {
           content: po.content,
           cachedAt: Date.now(),
           updatedAt: Date.now(),
-          tags: [],
         });
         cache.save(url, manuscript);
         res.send(manuscript.data);

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -47,15 +47,18 @@ app.post("/simplify", async (req, res) => {
       } else {
         console.log(`Saving contents of ${url}`);
         const po: readability.ParsedOutput = readability.parse(content);
-        manuscript = {
-          url,
+        manuscript = new cache.Manuscript({
+          url: url,
           title: po.title,
           siteName: po.siteName,
           byline: po.byline,
           excerpt: po.excerpt,
           textContent: po.textContent,
           content: po.content,
-        };
+          cachedAt: Date.now(),
+          updatedAt: Date.now(),
+          tags: [],
+        });
         cache.save(url, manuscript);
         res.send(manuscript);
       }


### PR DESCRIPTION
Add createdAt and updatedAt timestamps to the cached scribe manuscripts, and provide an endpoint to determine if a URL is in the cache or not.