### PR TITLE
Convert relative to absolute urls

### DIFF
--- a/milton-processor/readability.ts
+++ b/milton-processor/readability.ts
@@ -14,15 +14,46 @@ export interface ParsedOutput {
   content: string;
 }
 
-export function parse(htmlString: string): ParsedOutput {
-  console.log(`Starting parse at ${Date.now()}`);
-  const dom = new JSDOM(htmlString).window
-  console.log(`created dom ${Date.now()}`);
-  domPurify(dom).sanitize(dom.document, {WHOLE_DOCUMENT: true, IN_PLACE: true});
-  console.log(`sanitized ${Date.now()}`);
+export function parse(htmlString: string, baseUrl?: string): ParsedOutput {
+  console.debug(`Starting parse: ${Date.now()}`);
+  const dom = new JSDOM(htmlString).window;
+  console.debug(`Created DOM: ${Date.now()}`);
+
+  const window = domPurify(dom)
+  if (baseUrl) {
+    window.addHook('afterSanitizeAttributes', (node) => findAndConvertUrls(baseUrl, node));
+  }
+  window.sanitize(dom.document, {WHOLE_DOCUMENT: true, IN_PLACE: true});
+  console.debug(`Sanitized: ${Date.now()}`);
+
   const result = new Readability(dom.document).parse();
-  console.log(`readabilized ${Date.now()}`);
+  console.debug(`Readabilized: ${Date.now()}`);
+
   return result;
+}
+
+function findAndConvertUrls(baseUrl: string, node: Element) {
+  const linkAttributes = ['href', 'src'];
+
+  linkAttributes.forEach((attr) => {
+    if (node.hasAttribute(attr)) {
+      const url = toAbsoluteUrl(baseUrl, node.getAttribute(attr));
+      node.setAttribute(attr, url);
+    }
+  });
+}
+
+function toAbsoluteUrl(baseUrl: string, url: string): string {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+
+  try {
+    return new URL(url, baseUrl).href;
+  } catch (ex) {
+    // Something went wrong, just return original
+  }
+  return url;
 }
 
 export function fetchArticle(url: string, callback: (content: string, err: Error) => void) {

--- a/milton-processor/scribe.ts
+++ b/milton-processor/scribe.ts
@@ -55,7 +55,7 @@ app.post("/simplify", async (req, res) => {
         res.status(422).send(`Unable to fetch page: ${err.message}`);
       } else {
         console.log(`Saving contents of ${url}`);
-        const po: readability.ParsedOutput = readability.parse(content);
+        const po: readability.ParsedOutput = readability.parse(content, url);
         manuscript = new cache.Manuscript({
           url,
           title: po.title,


### PR DESCRIPTION
If there's a cleaner way, let me know, but this seemed to work on the few articles I tested.

Unfortunately, since Milton only sends the article contents, and not the URL, this won't work for the `/extract` endpoint as currently defined. We can either switch over to the `/simplify` endpoint, or add a url field to the `/extract` interface.