### PR TITLE
Save raw content in addition to readability output

### DIFF
--- a/milton-processor/cache.ts
+++ b/milton-processor/cache.ts
@@ -4,6 +4,9 @@ import base64url = require('base64url');
 import { ENVIRONMENT, CONFIG } from './scribe';
 
 
+const MANUSCRIPT_PATH = 'manuscript.json';
+const RAW_CONTENTS_PATH = 'raw_content';
+
 export interface ManuscriptData {
   url: string;
   title: string;
@@ -49,42 +52,67 @@ function sha256Hash(url: string): string {
   return base64url.default.fromBase64(crypto.createHash('sha256').update(url).digest('base64'));
 }
 
-function urlToKey(url: string): string {
-  return `${CONFIG.cache_prefix}/${sha256Hash(url)}.json`;
+function urlToFolder(url: string): string {
+  const folderPath =  `${CONFIG.cache_prefix}/${sha256Hash(url)}`;
+  console.debug(`URL ${url} located at: ${folderPath}`);
+  return folderPath;
 }
 
-function urlToFile(url: string): gcs.File {
+function urlToFile(url: string, filename: string): gcs.File {
   const storage = createStorageClient();
   const bucket = storage.bucket('scribe-storage');
-  const key = urlToKey(url);
-  console.debug(`URL ${url} located at: ${key}`);
+  const key = `${urlToFolder(url)}/${filename}`;
   return bucket.file(key);
 }
 
-export function save(url: string, contents: Manuscript) {
-  const file = urlToFile(url);
-  file.save(contents.toJson()).then(() => {
-    file.setMetadata({contentType: 'application/json'});
-    console.log(`Saved contents of URL (${url}) to cache`);
+export function saveRawContents(url: string, rawContents: any, contentType?: string) {
+  const file = urlToFile(url, RAW_CONTENTS_PATH);
+  file.save(rawContents).then(() => {
+    if (contentType) {
+      file.setMetadata({contentType});
+    }
+    console.log(`Saved raw contents of URL (${url}) to cache`);
   }).catch((err) => {
-    console.error(`Failed to save contents of URL (${url}) with error: ${err.message}`);
+    console.error(`Failed to save raw contents of URL (${url}) with error: ${err.message}`);
   });
 }
 
-export function fetch(url: string): Promise<Manuscript> {
-  const file = urlToFile(url);
+export function fetchRawContents(url: string): Promise<string> {
+  const file = urlToFile(url, RAW_CONTENTS_PATH);
+  const cachedContents = file.download().then((data) => {
+    const fileContents = data[0].toString();
+    return fileContents;
+  }).catch((err) => {
+    console.warn(`Failed to fetch raw content of URL (${url}) with error: ${err.message}`)
+    throw err;
+  });
+  return cachedContents;
+}
+
+export function saveManuscript(url: string, contents: Manuscript) {
+  const file = urlToFile(url, MANUSCRIPT_PATH);
+  file.save(contents.toJson()).then(() => {
+    file.setMetadata({contentType: 'application/json'});
+    console.log(`Saved manuscript of URL (${url}) to cache`);
+  }).catch((err) => {
+    console.error(`Failed to save manuscript of URL (${url}) with error: ${err.message}`);
+  });
+}
+
+export function fetchManuscript(url: string): Promise<Manuscript> {
+  const file = urlToFile(url, MANUSCRIPT_PATH);
   const cachedManuscript = file.download().then((data) => {
     const fileContents = data[0].toString();
     return Manuscript.fromJson(fileContents);
   }).catch((err) => {
-    console.warn(`Failed to fetch contents of URL (${url}) with error: ${err.message}`)
+    console.warn(`Failed to fetch manuscript of URL (${url}) with error: ${err.message}`)
     throw err;
   });
   return cachedManuscript;
 }
 
 export function isCached(url: string): Promise<boolean> {
-  const file = urlToFile(url);
+  const file = urlToFile(url, MANUSCRIPT_PATH);
   const exists = file.exists().then((data) => {
     return data[0];
   }).catch((err) => {

--- a/milton-processor/cache.ts
+++ b/milton-processor/cache.ts
@@ -79,13 +79,12 @@ export function saveRawContents(url: string, rawContents: any, contentType?: str
 
 export function fetchRawContents(url: string): Promise<string> {
   const file = urlToFile(url, RAW_CONTENTS_PATH);
-  const cachedContents = file.download().then((data) => {
-    const fileContents = data[0].toString();
-    return fileContents;
-  }).catch((err) => {
-    console.warn(`Failed to fetch raw content of URL (${url}) with error: ${err.message}`)
-    throw err;
-  });
+  const cachedContents = file.download()
+    .then(data => data[0].toString())
+    .catch(err => {
+      console.warn(`Failed to fetch raw content of URL (${url}) with error: ${err.message}`)
+      throw err;
+    });
   return cachedContents;
 }
 

--- a/milton-processor/fetcher.ts
+++ b/milton-processor/fetcher.ts
@@ -1,0 +1,63 @@
+import { IncomingHttpHeaders } from 'http';
+import * as RestClient from 'typed-rest-client/HttpClient';
+import { response } from 'express';
+
+export interface ArticleResponse {
+  headers: IncomingHttpHeaders;
+  body: string;
+  rawData: ArrayBuffer;
+}
+
+export class FetcherResponse {
+  contentType: string;
+  body: string;
+  rawData: ArrayBuffer;
+
+  constructor(contentType: string) {
+    this.contentType = contentType;
+  }
+
+  isTextual(): boolean {
+    return this.contentType.startsWith('text/');
+  }
+
+  addBody(body: string) {
+    this.body = body;
+  }
+
+  addRawData(rawData: ArrayBuffer) {
+    this.rawData = rawData;
+  }
+}
+
+export function fetchArticle(url: string): Promise<FetcherResponse> {
+  const httpClient = new RestClient.HttpClient('Scribe/1.0');
+  return httpClient.get(url).then((res) => {
+    const headers: IncomingHttpHeaders = res.message.headers;
+    const fetcherResponse = new FetcherResponse(headers["content-type"]);
+
+    if (fetcherResponse.isTextual()) {
+      return res.readBody().then((body) => {
+        fetcherResponse.addBody(body);
+        return fetcherResponse;
+      });
+    } else {
+      res.message.setEncoding('binary');
+
+      return new Promise((resolve, reject) => {
+        const chunks = [];
+        res.message.on('data', (chunk) => {
+          chunks.push(Buffer.from(chunk, 'binary'));
+        });
+        res.message.on('end', () => {
+          const binary = Buffer.concat(chunks);
+          fetcherResponse.addRawData(binary);
+          resolve(fetcherResponse);
+        });
+        res.message.on('error', (error) => {
+          reject(error);
+        });
+      });
+    }
+  });
+}

--- a/milton-processor/fetcher.ts
+++ b/milton-processor/fetcher.ts
@@ -18,7 +18,7 @@ export class FetcherResponse {
   }
 
   isTextual(): boolean {
-    return this.contentType.startsWith('text/');
+    return this.contentType.startsWith('text/html');
   }
 
   addBody(body: string) {

--- a/milton-processor/readability.ts
+++ b/milton-processor/readability.ts
@@ -1,7 +1,7 @@
 import jsdomLib = require('jsdom');
 import domPurify = require('dompurify');
 import Readability = require('readability');
-import * as RestClient from 'typed-rest-client/HttpClient';
+
 
 const JSDOM = jsdomLib.JSDOM;
 
@@ -56,8 +56,3 @@ function toAbsoluteUrl(baseUrl: string, url: string): string {
   }
   return url;
 }
-
-export function fetchArticle(url: string): Promise<string> {
-  const httpClient = new RestClient.HttpClient('Scribe/1.0');
-  return httpClient.get(url).then((res) => res.readBody());
-};


### PR DESCRIPTION
To allow for archival of PDF and other non-text formats, as well as a
backup in case the readability library mangles an article.