### PR TITLE
Add auth token support for simplify endpoint

### DIFF
--- a/milton-processor/.gitignore
+++ b/milton-processor/.gitignore
@@ -4,6 +4,6 @@
 # Exclude dependencies
 node_modules/
 
-secret
 .idea/
 key.json
+env.yaml

--- a/milton-processor/package.json
+++ b/milton-processor/package.json
@@ -15,7 +15,7 @@
     "start": "node ./index.js",
     "gcp-build": "tsc -p .",
     "deploy-appengine": "gcloud app deploy",
-    "deploy-function": "gcloud functions deploy scribe --runtime nodejs10 --allow-unauthenticated --trigger-http --memory 512MB --service-account scribe@dsouza-proving-ground.iam.gserviceaccount.com --set-env-vars NODE_ENV=prod"
+    "deploy-function": "gcloud functions deploy scribe --runtime nodejs10 --allow-unauthenticated --trigger-http --memory 512MB --service-account scribe@dsouza-proving-ground.iam.gserviceaccount.com --env-vars-file env.yaml"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.7.0",


### PR DESCRIPTION
Note that we aren't protecting the extract endpoint because it doesn't
actually make any outgoing requests, and so is less of a risk since it
can't be used for DDOS amplification attacks like the simplify endpoint
could.