### PR TITLE
Allow CORS for studio.dsouza.io

### DIFF
--- a/milton-processor/config.json
+++ b/milton-processor/config.json
@@ -6,7 +6,7 @@
       "node_port": 8081
   },
   "prod": {
-      "cors_client": "https://cdn.dsouza.io",
+      "cors_client": "https://studio.dsouza.io",
       "cache_prefix": "prod",
       "node_port": 8080
   }


### PR DESCRIPTION
I'm swapping my cdn.dsouza.io host over to studio.dsouza.io, so need to update the CORS allowlist here.